### PR TITLE
Bump `pify` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"file-system"
 	],
 	"dependencies": {
-		"pify": "^3.0.0"
+		"pify": "^4.0.1"
 	},
 	"devDependencies": {
 		"ava": "*",

--- a/test/async.js
+++ b/test/async.js
@@ -44,9 +44,10 @@ test('file exits', async t => {
 });
 
 test('root dir', async t => {
+	const mode = fs.statSync('/').mode & 0o777;
 	const dir = await m('/');
 	t.true(dir.length > 0);
-	assertDir(t, dir);
+	assertDir(t, dir, mode);
 });
 
 test('race two', async t => {

--- a/test/sync.js
+++ b/test/sync.js
@@ -46,9 +46,10 @@ test('file exits', t => {
 });
 
 test('root dir', t => {
+	const mode = fs.statSync('/').mode & 0o777;
 	const dir = m.sync('/');
 	t.true(dir.length > 0);
-	assertDir(t, dir);
+	assertDir(t, dir, mode);
 });
 
 test('race two', t => {


### PR DESCRIPTION
Also fix issue with `root dir` test where the mode of '/' on Linux is
0o555 instead of 0o775.

This should qualify as a semver-minor change since make-dir already requires node.js 6.