### PR TITLE
Fetch fresh `process.umask()` on every method call

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const processOptions = options => {
 		mode: 0o777 & (~process.umask()),
 		fs
 	};
+
 	return {
 		...defaults,
 		...options

--- a/index.js
+++ b/index.js
@@ -4,11 +4,6 @@ const path = require('path');
 const {promisify} = require('util');
 const semver = require('semver');
 
-const defaults = {
-	mode: 0o777 & (~process.umask()),
-	fs
-};
-
 const useNativeRecursiveOption = semver.satisfies(process.version, '>=10.12.0');
 
 // https://github.com/nodejs/node/issues/8987
@@ -25,6 +20,18 @@ const checkPath = pth => {
 	}
 };
 
+const processOptions = options => {
+	// https://github.com/sindresorhus/make-dir/issues/18
+	const defaults = {
+		mode: 0o777 & (~process.umask()),
+		fs
+	};
+	return {
+		...defaults,
+		...options
+	};
+};
+
 const permissionError = pth => {
 	// This replicates the exception of `fs.mkdir` with native the
 	// `recusive` option when run on an invalid drive under Windows.
@@ -38,10 +45,7 @@ const permissionError = pth => {
 
 const makeDir = async (input, options) => {
 	checkPath(input);
-	options = {
-		...defaults,
-		...options
-	};
+	options = processOptions(options);
 
 	const mkdir = promisify(options.fs.mkdir);
 	const stat = promisify(options.fs.stat);
@@ -97,10 +101,7 @@ module.exports = makeDir;
 
 module.exports.sync = (input, options) => {
 	checkPath(input);
-	options = {
-		...defaults,
-		...options
-	};
+	options = processOptions(options);
 
 	if (useNativeRecursiveOption && options.fs.mkdirSync === fs.mkdirSync) {
 		const pth = path.resolve(input);

--- a/test/umask.js
+++ b/test/umask.js
@@ -1,0 +1,19 @@
+import test from 'ava';
+import {getFixture, assertDirectory} from './helpers/util';
+import makeDir from '..';
+
+test.before(() => {
+	process.umask(0);
+});
+
+test('async', async t => {
+	const dir = getFixture();
+	await makeDir(dir);
+	assertDirectory(t, dir, 0o777 & (~process.umask()));
+});
+
+test('sync', t => {
+	const dir = getFixture();
+	makeDir.sync(dir);
+	assertDirectory(t, dir, 0o777 & (~process.umask()));
+});


### PR DESCRIPTION
Fixes #18

Included test case that failed before.