### PR TITLE
Stop using deprecated `process.umask()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ declare namespace makeDir {
 		/**
 		Directory [permissions](https://x-team.com/blog/file-system-permissions-umask-node-js/).
 
-		@default 0o777 & (~process.umask())
+		@default 0o777
 		*/
 		readonly mode?: number;
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const checkPath = pth => {
 const processOptions = options => {
 	// https://github.com/sindresorhus/make-dir/issues/18
 	const defaults = {
-		mode: 0o777 & (~process.umask()),
+		mode: 0o777,
 		fs
 	};
 

--- a/readme.md
+++ b/readme.md
@@ -90,7 +90,7 @@ Type: `object`
 ##### mode
 
 Type: `integer`\
-Default: `0o777 & (~process.umask())`
+Default: `0o777`
 
 Directory [permissions](https://x-team.com/blog/file-system-permissions-umask-node-js/).
 

--- a/test/helpers/util.js
+++ b/test/helpers/util.js
@@ -5,7 +5,19 @@ import pathType from 'path-type';
 
 export const getFixture = () => path.join(tempy.directory(), 'a/b/c/unicorn_unicorn_unicorn/d/e/f/g/h');
 
-export const assertDirectory = (t, directory, mode = 0o777 & (~process.umask())) => {
+let lastMask = 0;
+
+function umask() {
+	// Avoid deprecation warning in v14+
+	lastMask = process.umask(lastMask);
+	process.umask(lastMask);
+	return lastMask;
+}
+
+// Get the initial value before any async operations start
+umask();
+
+export const assertDirectory = (t, directory, mode = 0o777 & (~umask())) => {
 	// Setting `mode` on `fs.mkdir` on Windows doesn't seem to work
 	if (process.platform === 'win32') {
 		mode = 0o666;

--- a/test/umask.js
+++ b/test/umask.js
@@ -2,18 +2,19 @@ import test from 'ava';
 import {getFixture, assertDirectory} from './helpers/util';
 import makeDir from '..';
 
+const mask = 0;
 test.before(() => {
-	process.umask(0);
+	process.umask(mask);
 });
 
 test('async', async t => {
 	const dir = getFixture();
 	await makeDir(dir);
-	assertDirectory(t, dir, 0o777 & (~process.umask()));
+	assertDirectory(t, dir, 0o777 & (~mask));
 });
 
 test('sync', t => {
 	const dir = getFixture();
 	makeDir.sync(dir);
-	assertDirectory(t, dir, 0o777 & (~process.umask()));
+	assertDirectory(t, dir, 0o777 & (~mask));
 });


### PR DESCRIPTION
Fixes #27

---

Note readme.md and index.d.ts both still reference `0o777 & (~process.umask())` as the default value to mode.  I'm not sure the best way to update these two places.